### PR TITLE
add automation to build and push images

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags: '*'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup the environment
+        run: |
+          TAG=${GITHUB_REF#refs/heads/}
+          REPO="docker.io/ohiosupercomputer"
+          echo "LATEST_IMG=$REPO/ood-doc-build:latest" >> $GITHUB_ENV
+          echo "VERSIONED_IMG=$REPO/ood-doc-build:$TAG" >> $GITHUB_ENV
+      - name: docker build and tag
+        run: | 
+          docker build -t $LATEST_IMG .
+          docker tag $LATEST_IMG $VERSIONED_IMG
+      - name: login to dockerhub
+        run: docker login -u oscrobot -p ${{ secrets.OSC_ROBOT_DOCKERHUB_TOKEN }}
+      - name: push images to dockerhub
+        run: |
+          docker push $LATEST_IMG
+          docker push $VERSIONED_IMG


### PR DESCRIPTION
add automation to build and push images. Fairly straight forward.  On every tag build and push the image. Note I've changed the image name to `ood-doc-build` to get rid of the sphinx name. So the old image will continue to exist and be useful to the ood-documentation repo while we update and version the new image as we please.