### PR TITLE
add myst package to container

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sphinxcontrib-httpdomain==1.7.0
 docutils==0.20
 sphinx-tabs==3.4.5
 sphinxcontrib-spelling
+myst-parser


### PR DESCRIPTION
Fixes #26. Adds the myst-parser package through pip (via requirements.txt)